### PR TITLE
update models & add tag gem to use in Recipes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rails', '5.0.5'
 gem 'redis'
 gem 'cloudinary'
 gem 'carrierwave', '~> 0.11.2'
+gem 'acts-as-taggable-on', '~> 4.0'
 
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (4.0.0)
+      activerecord (>= 4.0)
     arel (7.1.4)
     autoprefixer-rails (7.1.2.6)
       execjs
@@ -209,6 +211,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 4.0)
   autoprefixer-rails
   bootstrap-sass
   carrierwave (~> 0.11.2)

--- a/app/models/dose.rb
+++ b/app/models/dose.rb
@@ -1,4 +1,7 @@
 class Dose < ApplicationRecord
   belongs_to :ingredient
   belongs_to :recipe
+
+  validates :description, :ingredient_id, :recipe_id, presence: true
+
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,6 +1,20 @@
 class Ingredient < ApplicationRecord
   has_many :doses
+
   validates :name, presence: true, uniqueness: true
-  validates :january, presence: true, inclusion: { :in => [0, 50, 100]}
+
+  validates :january, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :february, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :march, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :april, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :may, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :june, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :july, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :august, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :september, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :october, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :november, presence: true, inclusion: { :in => [0, 50, 100] }
+  validates :december, presence: true, inclusion: { :in => [0, 50, 100] }
+
   mount_uploader :photo, PhotoUploader
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,5 +1,42 @@
 class Recipe < ApplicationRecord
   has_many :doses
   has_many :past_recommendations
+
   mount_uploader :photo, PhotoUploader
+
+  validates :name, presence: true, uniqueness: true
+  validates :instructions, :servings, presence: true
+
+  DIFFICULTIES = ["Très facile", "Facile", "Moyen", "Difficile"]
+  validates :difficulty, inclusion: { :in => DIFFICULTIES }
+
+  #permet de créer des listes de tags avec la gem act_as_taggable
+  acts_as_taggable_on :seasons, :recipe_types, :diets
+  #valide qu'un tag est présent dans :recipe_types
+  validates :recipe_type_list, presence: true
+  #valide que chaque tag ajouté existe dans la constante
+  validate :validate_recipe_type, :validate_season_list
+
+  RECIPE_TYPES = ["Apéritif", "Entrée", "Plat", "Accompagnement", "Dessert", "Boisson", "Petit-déjeuner", "Snack"]
+  SEASONS = ["Printemps", "Eté", "Automne", "Hiver"]
+  DIETS = ["Vegan"]
+
+  #méthodes custom de validation des tags
+  def validate_season_list
+    season_list.each do |season|
+      record.errors[:season_list] << 'Not available!' unless SEASONS.include? season
+    end
+  end
+
+  def validate_recipe_type
+    recipe_type_list.each do |type|
+      record.errors[:recipe_type_list] << 'Not available!' unless RECIPE_TYPES.include? type
+    end
+  end
+
+   def validate_diet_list
+    diet_list.each do |diet|
+      record.errors[:diet_list] << 'Not available!' unless DIETS.include? diet
+    end
+  end
 end

--- a/db/migrate/20170822142826_update_recipe_with_new_type_recipe.rb
+++ b/db/migrate/20170822142826_update_recipe_with_new_type_recipe.rb
@@ -1,0 +1,5 @@
+class UpdateRecipeWithNewTypeRecipe < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :recipes, :type, :recipe_type
+  end
+end

--- a/db/migrate/20170822150750_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20170822150750_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,31 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20170822150751_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20170822150751_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,21 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20170822150752_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20170822150752_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20170822150753_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20170822150753_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20170822150754_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20170822150754_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20170822150755_add_missing_indexes.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20170822150755_add_missing_indexes.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexes < ActiveRecord::Migration
+  def change
+    add_index :taggings, :tag_id
+    add_index :taggings, :taggable_id
+    add_index :taggings, :taggable_type
+    add_index :taggings, :tagger_id
+    add_index :taggings, :context
+
+    add_index :taggings, [:tagger_id, :tagger_type]
+    add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+  end
+end

--- a/db/migrate/20170822164253_remove_seasons_types_veganfrom_recipes.rb
+++ b/db/migrate/20170822164253_remove_seasons_types_veganfrom_recipes.rb
@@ -1,0 +1,7 @@
+class RemoveSeasonsTypesVeganfromRecipes < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :recipes, :recipe_type
+    remove_column :recipes, :seasonality
+    remove_column :recipes, :vegan
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170822132445) do
+ActiveRecord::Schema.define(version: 20170822164253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,13 +60,35 @@ ActiveRecord::Schema.define(version: 20170822132445) do
     t.integer  "cooking_time"
     t.integer  "preparation_time"
     t.string   "difficulty"
-    t.string   "type"
     t.integer  "servings"
-    t.integer  "seasonality"
-    t.boolean  "vegan"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
     t.string   "photo"
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer  "tag_id"
+    t.string   "taggable_type"
+    t.integer  "taggable_id"
+    t.string   "tagger_type"
+    t.integer  "tagger_id"
+    t.string   "context",       limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context", using: :btree
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+    t.index ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy", using: :btree
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id", using: :btree
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type", using: :btree
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id", using: :btree
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string  "name"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true, using: :btree
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
doses model
ingredients model
recipes model
remove 3 columns from recipe DB (type, seasonnality, diets)
acts_as_taggable_on gem to manage tags list in recipe: seasons, diets, types
